### PR TITLE
Updated django_data.sh script

### DIFF
--- a/DB_RESET_SEED_SYSTEM.md
+++ b/DB_RESET_SEED_SYSTEM.md
@@ -42,8 +42,8 @@ You _can_ manually delete the db stuff, then directly run the custom command fil
 ```bash
 #!/bin/bash
 
-find . -path "'$1'/migrations/*.py" -not -name "__init__.py" -delete; #deletes all of the .py files in the migrations directory except for the __init__.py file.
-find . -path "'$1'/migrations/*.pyc"  -delete; #deletes all of the .pyc files in the migrations directory.
+find . -path "./$1/migrations/*.py" -not -name "__init__.py" -delete; #deletes all of the .py files in the migrations directory except for the __init__.py file.
+find . -path "./$1/migrations/*.pyc"  -delete; #deletes all of the .pyc files in the migrations directory.
 rm db.sqlite3; #deletes the database file.
 python manage.py makemigrations $1; #creates the migration and the new db file.
 python manage.py migrate; #runs the migration.

--- a/DB_RESET_SEED_SYSTEM.md
+++ b/DB_RESET_SEED_SYSTEM.md
@@ -42,8 +42,8 @@ You _can_ manually delete the db stuff, then directly run the custom command fil
 ```bash
 #!/bin/bash
 
-find . -path "/$1/migrations/*.py" -not -name "__init__.py" -delete; #deletes all of the .py files in the migrations directory except for the __init__.py file.
-find . -path "/$1/migrations/*.pyc"  -delete; #deletes all of the .pyc files in the migrations directory.
+find . -path "'$1'/migrations/*.py" -not -name "__init__.py" -delete; #deletes all of the .py files in the migrations directory except for the __init__.py file.
+find . -path "'$1'/migrations/*.pyc"  -delete; #deletes all of the .pyc files in the migrations directory.
 rm db.sqlite3; #deletes the database file.
 python manage.py makemigrations $1; #creates the migration and the new db file.
 python manage.py migrate; #runs the migration.


### PR DESCRIPTION
Hi, it's me again, your friendly neighborhood Cashew. For some reason when you try and run this file, the path commands will not delete migrations that are not "__init__.py" as intended. After some spike testing (yes uncle Max from Cohort 1 taught me a word/thing when we pair programmed 😄), I discovered that in order to get this find path code to work with the inputted command line arguments you must add a . before the slash. (I really don't know why this needs to be like this [especially since you are using find on the directory you are in with a . already so it seems redundant...] but I haven't really understood or gotten into command line prompts/arguments/whatever this magic is. But it now works. [Alternatively you could also write it like "\*/migrations/*.pyc" & "\*/migrations/*.pyc", but I like this version better because its more targeted to a specific apps migration.]) Now hopefully when people paste this setup into their django_data.sh file it will work for them accordingly. I can only vouch it works for me on my Mac OS, I haven't had it tested in another system. 

**PS** I know most of cohort 25 has a working version of this now, but not all of us.

**PPS** I have found that you CAN make this work properly for foreign keys you just have to be very conscious of the order in which you are making and calling your models and faker data. For example, you cant make something from your faker command if the foreign key it needs to add doesn't have a model/information built for it yet. I did not make an adjustment to the note on line 62 as I wanted to leave that decision to you. 👩‍💻 👨‍💻

This was the previous code in the doc:
```
find . -path "/$1/migrations/*.py" -not -name "__init__.py" -delete; #deletes all of the .py files in the migrations directory except for the __init__.py file.
find . -path "/$1/migrations/*.pyc"  -delete; #deletes all of the .pyc files in the migrations directory.
```

This is the new code adjustment I made:
```
find . -path "./$1/migrations/*.py" -not -name "__init__.py" -delete; #deletes all of the .py files in the migrations directory except for the __init__.py file.
find . -path "./$1/migrations/*.pyc"  -delete; #deletes all of the .pyc files in the migrations directory.
```