### PR TITLE
Add packages import exercise

### DIFF
--- a/book-1-orientation/chapters/PYTHON_PACKAGES.md
+++ b/book-1-orientation/chapters/PYTHON_PACKAGES.md
@@ -64,3 +64,8 @@ from appliances import AirConditioner
 kenmore = Washer()
 samsung = Refrigerator()
 ```
+
+## Practice: Importing Packages
+Clone this repo and refactor it to make it run error-free. Run `index.py` and use the error msg to figure out where to start. Once the errors are gone, create a can opener and open a can (But hold your nose!)
+
+https://github.com/nashville-software-school/python-imports

--- a/book-1-orientation/chapters/PYTHON_PACKAGES.md
+++ b/book-1-orientation/chapters/PYTHON_PACKAGES.md
@@ -66,6 +66,6 @@ samsung = Refrigerator()
 ```
 
 ## Practice: Importing Packages
-Clone this repo and refactor it to make it run error-free. Run `index.py` and use the error msg to figure out where to start. Once the errors are gone, create a can opener and open a can (But hold your nose!)
+Clone this repo and refactor it to make it run error-free. Run `index.py` and use the error message to figure out where to start. Once the errors are gone, create a can opener and open a can (But hold your nose!)
 
 https://github.com/nashville-software-school/python-imports


### PR DESCRIPTION
The newly added packages chapter in python orientation ( Book 1 ), needs an exercise to allow students to practice creating packages with `__init__.py` files, and importing those packages.
I have added one that links to a boilerplate repo that contains intentional import errors, as well as an opportunity to create additional imports