### PR TITLE
Kn mac install troubleshoot

### DIFF
--- a/book-1-orientation/chapters/INSTALLATIONS_OSX.md
+++ b/book-1-orientation/chapters/INSTALLATIONS_OSX.md
@@ -39,7 +39,7 @@ if command -v pyenv 1>/dev/null 2>&1; then
 fi
 ```
 
-If you are a Mac user on Mojave, and receive a similar error to the one below when trying to run `pyenv install 3.7.3`
+If try to run `pyenv install 3.7.3` and receive an error similar to the one below 
 
 ```
 BUILD FAILED (OS X 10.14.6 using python-build 20180424)
@@ -51,6 +51,8 @@ Run the following command in your terminal:
  ```
  sudo installer -pkg /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg -target / 
  ```
+
+ After this is completed, try running `pyenv install 3.7.3` again
 
 
 ## Python Linter

--- a/book-1-orientation/chapters/INSTALLATIONS_OSX.md
+++ b/book-1-orientation/chapters/INSTALLATIONS_OSX.md
@@ -39,6 +39,20 @@ if command -v pyenv 1>/dev/null 2>&1; then
 fi
 ```
 
+If you are a Mac user on Mojave, and receive a similar error to the one below when trying to run `pyenv install 3.7.3`
+
+```
+BUILD FAILED (OS X 10.14.6 using python-build 20180424)
+
+Inspect or clean up the working tree at /var/folders/r5/snljcx4x3dx8ccckm7hhdgy80000gn/T/python-build.20191008104728.34069 Results logged to /var/folders/r5/snljcx4x3dx8ccckm7hhdgy80000gn/T/python-build.20191008104728.34069.log
+```
+
+Run the following command in your terminal:
+ ```
+ sudo installer -pkg /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg -target / 
+ ```
+
+
 ## Python Linter
 
 Run the following command to install the linter we will all be using during Python development.


### PR DESCRIPTION
When going through the OSX install chapter, I ran into an error when running `pyenv install 3.7.3`.

I added the command I needed to run in my terminal in order to get `pyenv install 3.7.3` to run and update the version of Python I had installed. In my googling it appeared to be an error that Mac Users on Mojave ran into.

1. `git fetch --all`
2. `git checkout kn-macInstallTroubleshoot`
3. Verify that there has been a section added under **Troubleshooting pyenv** to troubleshoot a `Build Failed` error when running `pyenv install 3.7.3`