### PR TITLE
Change url to path in Django routing examples

### DIFF
--- a/book-3-web-applications/chapters/DJANGO_AUTHENTICATION.md
+++ b/book-3-web-applications/chapters/DJANGO_AUTHENTICATION.md
@@ -2,10 +2,10 @@
 
 ## Setting up the Routes
 
-Open `libraryapp/urls.py` and update your import statement to import the include method from the `django.conf.urls` package.
+Open `libraryapp/urls.py` and update your import statement to import the include method from the `django.urls` package.
 
 ```py
-from django.conf.urls import url, include
+from django.urls import include, path
 ```
 
 
@@ -14,7 +14,7 @@ Then add the URLs to your existing patterns. This lets your application use the 
 > #### libraryproject/libraryapp/urls.py
 
 ```py
-url(r'accounts/', include('django.contrib.auth.urls')),
+path('accounts/', include('django.contrib.auth.urls')),
 ```
 
 You never need to touch these views, and they live in Django and have all the logic you need.
@@ -41,7 +41,7 @@ By default, the Django logout function takes the user to the admin site, which y
 > #### libraryproject/libraryapp/urls.py
 
 ```py
-url(r'^logout/$', logout_user, name='logout'),
+path('logout/', logout_user, name='logout'),
 ```
 
 ### Redirect on Logout

--- a/book-3-web-applications/chapters/DJANGO_EDIT_FORMS.md
+++ b/book-3-web-applications/chapters/DJANGO_EDIT_FORMS.md
@@ -81,7 +81,7 @@ This is a new URL pattern, so you need to add the following pattern to your `url
 > #### libraryproject/libraryapp/urls.py
 
 ```py
-url(r'^books/(?P<book_id>[0-9]+)/form$', book_edit_form, name='book_edit_form'),
+path('books/<int:book_id>/form/', book_edit_form, name='book_edit_form'),
 ```
 
 ### Book Edit Form View

--- a/book-3-web-applications/chapters/DJANGO_FORMS.md
+++ b/book-3-web-applications/chapters/DJANGO_FORMS.md
@@ -56,7 +56,7 @@ Time for you to implement your first form so that users can enter in a new book 
 Create the following entry in your URL patterns so that clients can request the book creation form.
 
 ```py
-url(r'^book/form$', book_form, name='book_form'),
+path('book/form', book_form, name='book_form'),
 ```
 
 ## Handling GET and POST Requests
@@ -121,7 +121,7 @@ Where should the request be sent. Thinking back to chapter 1 where you reviewed 
 You already have a pattern defined in `urls.py` for that URL.
 
 ```py
-url(r'^books$', book_list, name='books'),
+path('books', book_list, name='books'),
 ```
 
 That means that you have to refactor the `book_list()` method to handle a POST. That method already handles a GET request, so place the following code in your file at the bottom to handle the case of the request method being POST.

--- a/book-3-web-applications/chapters/DJANGO_VIEWS.md
+++ b/book-3-web-applications/chapters/DJANGO_VIEWS.md
@@ -116,14 +116,14 @@ Create a `urls.py` file in the `libraryapp` directory. This file will define all
 > #### libraryproject/libraryapp/urls.py
 
 ```py
-from django.conf.urls import url
+from django.urls import path
 from .views import *
 
 app_name = "libraryapp"
 
 urlpatterns = [
-    url(r'^$', book_list, name='home'),
-    url(r'^books$', book_list, name='books'),
+    path('', book_list, name='home'),
+    path('books/', book_list, name='books'),
 ]
 ```
 
@@ -140,13 +140,13 @@ Then in the `libraryproject/urls.py` file, include the URL mappings from your `l
 
 ```py
 from django.contrib import admin
-from django.conf.urls import include, url
+from django.urls import include, path
 from django.urls import path
 from libraryapp.models import *
 
 urlpatterns = [
     path('admin/', admin.site.urls),
-    url(r'^', include('libraryapp.urls')),
+    path('', include('libraryapp.urls')),
 ]
 ```
 
@@ -348,7 +348,7 @@ Then your `templates/librarians/list.html` template will iterate the `all_librar
 Also make sure you add your URL pattern.
 
 ```py
-url(r'^librarians$', librarian_list, name='librarians'),
+path('librarians/', librarian_list, name='librarians'),
 ```
 
 ## Library View
@@ -495,7 +495,7 @@ Update the `'home'` pattern in your application URLs.
 
 ```py
 urlpatterns = [
-    url(r'^$', home, name='home'),
-    url(r'^books$', book_list, name='books'),
+    path('', home, name='home'),
+    path('books/', book_list, name='books'),
 ]
 ```

--- a/book-4-full-stack/chapters/API_APPLICATION.md
+++ b/book-4-full-stack/chapters/API_APPLICATION.md
@@ -61,16 +61,16 @@ CORS_ORIGIN_WHITELIST = (
 Replace the contents of `kennywood/urls.py` with the following code. You will configure the routes for your application in the next chapter after you set up your first view.
 
 ```py
-from django.conf.urls import url, include
+from django.urls import include, path
 from rest_framework import routers
 from rest_framework.authtoken.views import obtain_auth_token
 
 router = routers.DefaultRouter(trailing_slash=False)
 
 urlpatterns = [
-    url(r'^', include(router.urls)),
-    url(r'^api-token-auth/', obtain_auth_token),
-    url(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework')),
+    path('', include(router.urls)),
+    path('api-token-auth/', obtain_auth_token),
+    path('api-auth/', include('rest_framework.urls', namespace='rest_framework')),
 ]
 ```
 

--- a/book-4-full-stack/chapters/DJANGO_REST_SETUP_GUIDE.md
+++ b/book-4-full-stack/chapters/DJANGO_REST_SETUP_GUIDE.md
@@ -68,7 +68,7 @@
         1. router.register(r'bar', views.MyBarViewSet)
         2. router.register(r'users', views.UserViewSet)
     5. Then in the url_patterns list, you only have to include one line (?)
-        1. url(r'^', include(router.urls))
+        1. path('', include(router.urls))
     6. Finally, add the bar/urls.py to the root project urls.py file
 14. Create an endpoint for the root of the API, which is basically a table of contents
     1. Tutorial link: http://www.django-rest-framework.org/tutorial/5-relationships-and-hyperlinked-apis/#creating-an-endpoint-for-the-root-of-our-api

--- a/book-4-full-stack/chapters/DRF_TOKEN_AUTH.md
+++ b/book-4-full-stack/chapters/DRF_TOKEN_AUTH.md
@@ -110,10 +110,10 @@ Then set up those new routes to map to `/register`, and `/login`.
 
 ```py
 urlpatterns = [
-    url(r'^', include(router.urls)),
-    url(r'^register$', register_user),
-    url(r'^login$', login_user),
-    url(r'^api-token-auth$', obtain_auth_token),
-    url(r'^api-auth$', include('rest_framework.urls', namespace='rest_framework')),
+    path('', include(router.urls)),
+    path('register/', register_user),
+    path('login/', login_user),
+    path('api-token-auth/', obtain_auth_token),
+    path('api-auth/', include('rest_framework.urls', namespace='rest_framework')),
 ]
 ```


### PR DESCRIPTION
Newer versions of Django eschew the `url` module in the url dispatcher, and instead use `path`, which also does away with regex patterns in the urls themselves.

I've updated the example code to reflect this usage.