### PR TITLE
docs: updated 'source activate' Django command path to differentiate Mac/PC users

### DIFF
--- a/book-3-web-applications/chapters/DJANGO_INTRO_LIBRARY.md
+++ b/book-3-web-applications/chapters/DJANGO_INTRO_LIBRARY.md
@@ -57,12 +57,21 @@ The next step is to create a virtual environment which prevents your operating s
 
 At the level of your project's directory where your `manage.py` file is, set up your virtual environment.
 
+#### Mac users, run the following:
 ```sh
 python -m venv libraryenv
 source ./libraryenv/bin/activate
 pip install django
 pip freeze > requirements.txt
 ```
+#### Windows users, run the following:
+```sh
+python -m venv libraryenv
+source ./libraryenv/Scripts/activate
+pip install django
+pip freeze > requirements.txt
+```
+> Note the separate formats for the `source` command between Windows and Mac users. You will use this command each time you activate your virtual environment for your project.
 
 > Now would be a great time to setup your .gitignore file in the project directory and then make your repo. Make sure you gitignore your environment.
 


### PR DESCRIPTION
# Overview
Updated the Django Intro documentation to include separate `source ... activate` command for PC users when activating their virtual environment

# Testing Instructions
1. **If someone could help me with the proper commands to put here in the future for submitting PRs from a forked branch, I am not sure the specific path formatting, unless it's the same as below...**
1. `git checkout master`
1. `git fetch --all`
1. `git checkout docs/venv-activate-windows-users`
1. View the preview of the file named `book-3-web-applications/chapters/DJANGO_INTRO_LIBRARY.md
` and check the new section in lines 60-74 pertinent to PC users.