### PR TITLE
Removed all references to useContext hook

### DIFF
--- a/book-2-levelup/chapters/LU_CREATE_GAME.md
+++ b/book-2-levelup/chapters/LU_CREATE_GAME.md
@@ -37,14 +37,14 @@ Now create a **`GameForm`** component and add the code below. Notice that the bu
 > #### `src/components/game/GameForm.js`
 
 ```jsx
-import React, { useContext, useState, useEffect } from "react"
-import { GameContext } from "./GameProvider.js"
+import React, { useState, useEffect } from "react"
 import { useHistory } from 'react-router-dom'
+import { createGame, getGameTypes } from './GameManager.js'
 
 
 export const GameForm = () => {
     const history = useHistory()
-    const { createGame, getGameTypes, gameTypes } = useContext(GameContext)
+    const [gameTypes, populateGameTypes] = useState([])
 
     /*
         Since the input fields are bound to the values of
@@ -65,6 +65,9 @@ export const GameForm = () => {
     */
     useEffect(() => {
         getGameTypes()
+            .then(data => {
+                populateGameTypes(data)
+            })
     }, [])
 
     /*

--- a/book-2-levelup/chapters/LU_CUSTOM_ACTION.md
+++ b/book-2-levelup/chapters/LU_CUSTOM_ACTION.md
@@ -40,7 +40,7 @@ def signup(self, request, pk=None):
     # Django uses the `Authorization` header to determine
     # which user is making the request to sign up
     gamer = Gamer.objects.get(user=request.auth.user)
-    
+
     try:
         # Handle the case if the client specifies a game
         # that doesn't exist
@@ -98,17 +98,23 @@ Now you need to update your **`EventList`** component in the client to allow the
 Then that function is invoked when the join button - which is on the bottom of each event card - is clicked.
 
 ```jsx
-import React, { useContext, useEffect } from "react"
+import React, { useEffect } from "react"
 import { EventContext } from "./EventProvider.js"
 import { useHistory } from "react-router-dom"
+import { getEvents, joinEvent } from "./EventManager.js"
 import "./Events.css"
 
 export const EventList = () => {
     const history = useHistory()
-    const { events, getEvents, joinEvent } = useContext(EventContext)
+    const [ events, assignEvents ] = useState([])
+
+    const eventFetcher = () => {
+        getEvents()
+            .then(data => assignEvents(data))
+    }
 
     useEffect(() => {
-        getEvents()
+        eventFetcher()
     }, [])
 
     return (
@@ -131,7 +137,12 @@ export const EventList = () => {
                             {event.date} @ {event.time}
                         </div>
                         <button className="btn btn-2"
-                                onClick={() => joinEvent(event.id)}
+                                onClick={
+                                    () => {
+                                        joinEvent(event.id)
+                                            .then(() => eventFetcher())
+                                    }
+                                }
                         >Join</button>
                     </section>
                 })

--- a/book-2-levelup/chapters/LU_EVENTS.md
+++ b/book-2-levelup/chapters/LU_EVENTS.md
@@ -293,14 +293,15 @@ export const EventProvider = (props) => {
 > #### `src/components/game/EventList.js`
 
 ```jsx
-import React, { useContext, useEffect } from "react"
-import { EventContext } from "./EventProvider.js"
+import React, { useEffect } from "react"
+import { getEvents } from "./EventManager.js"
 
 export const EventList = (props) => {
-    const { events, getEvents } = useContext(EventContext)
+    const [ events, updateEvents ] = useState([])
 
     useEffect(() => {
         getEvents()
+            .then(data => updateEvents(data))
     }, [])
 
     return (

--- a/book-2-levelup/chapters/LU_GAMES.md
+++ b/book-2-levelup/chapters/LU_GAMES.md
@@ -306,14 +306,14 @@ export const GameProvider = (props) => {
 > #### `src/components/game/GameList.js`
 
 ```jsx
-import React, { useContext, useEffect } from "react"
-import { GameContext } from "./GameProvider.js"
+import React, { useEffect } from "react"
+import { getGames } from "./GameManager.js"
 
 export const GameList = (props) => {
-    const { games, getGames } = useContext(GameContext)
+    const [ games, setGames ] = useState([])
 
     useEffect(() => {
-        getGames()
+        getGames().then(data => setGames(data))
     }, [])
 
     return (

--- a/book-2-levelup/chapters/LU_GAME_EVENTS.md
+++ b/book-2-levelup/chapters/LU_GAME_EVENTS.md
@@ -27,7 +27,7 @@ You are only provided with a small sample of code in this chapter. You have to b
 > #### `src/components/event/EventForm.js`
 
 ```jsx
-import React, { useContext, useState, useEffect } from "react"
+import React, { useState, useEffect } from "react"
 import { useHistory } from "react-router-dom"
 
 

--- a/book-2-levelup/chapters/LU_MODEL_PROPERTY.md
+++ b/book-2-levelup/chapters/LU_MODEL_PROPERTY.md
@@ -173,17 +173,21 @@ In React, you need to update your **`EventList`** component in the client to all
 > **Vocabulary:** `condition ? what happens if true : what happens if false` is called a ternary statement in JavaScript. It's a condensed version of an `if..else` block of code that you can use in JSX, because interpolation only supports a single JavaScript statement.
 
 ```jsx
-import React, { useContext, useEffect } from "react"
-import { EventContext } from "./EventProvider.js"
+import React, { useEffect } from "react"
 import { useHistory } from "react-router-dom"
+import { getEvents, joinEvent, leaveEvent } from "./EventManager.js"
 import "./Events.css"
 
 export const EventList = () => {
     const history = useHistory()
-    const { events, getEvents, joinEvent, leaveEvent } = useContext(EventContext)
+    const [ events, updateEvents ] = useState([])
+
+    const eventFetcher = () => {
+        getEvents().then(data => updateEvents(data))
+    }
 
     useEffect(() => {
-        getEvents()
+        eventFetcher()
     }, [])
 
     return (
@@ -207,10 +211,10 @@ export const EventList = () => {
                         {
                             event.joined
                                 ? <button className="btn btn-3"
-                                    onClick={() => leaveEvent(event.id)}
+                                    onClick={() => leaveEvent(event.id).then(() => eventFetcher())}
                                     >Leave</button>
                                 : <button className="btn btn-2"
-                                    onClick={() => joinEvent(event.id)}
+                                    onClick={() => joinEvent(event.id).then(() => eventFetcher())}
                                     >Join</button>
                         }
                     </section>

--- a/book-2-levelup/chapters/LU_PROFILE.md
+++ b/book-2-levelup/chapters/LU_PROFILE.md
@@ -206,16 +206,16 @@ Create a profile HTML representation component. In this code you will notice str
 Your instruction team will review this with you to explain how this is useful for working with React component lifecycle _(remember that the JSX is rendered before you have the data)_.
 
 ```jsx
-import React, { useEffect, useContext } from "react"
-import { ProfileContext } from "./ProfileProvider.js"
+import React, { useEffect } from "react"
+import { getProfile } from "./ProfileManager.js"
 import "./Profile.css"
 
 
 export const Profile = () => {
-    const { profile, getProfile } = useContext(ProfileContext)
+    const [ profile, changeProfile ] = useState([])
 
     useEffect(() => {
-        getProfile()
+        getProfile().then(data => changeProfile(data))
     }, [])
 
     return (


### PR DESCRIPTION
Removed all references to `useContext()` hook. In all places, provided code for importing functions from a `*Manager.js` which perform the HTTP requests, and then updating state that is in the component instead of in a context provider.

@hannahhall There were so few instances of `useContext()` that I made all replacements.