### PR TITLE
Fix link to image

### DIFF
--- a/book-2-levelup/chapters/LU-view-serializer-interlude.md
+++ b/book-2-levelup/chapters/LU-view-serializer-interlude.md
@@ -88,7 +88,7 @@ The `Meta` class inside the serializer holds the configuration info to use for t
 
 Any time that you want to allow a client to access data in your database, there's a series of steps you have to follow in order to accomplish it with Django REST Framework. So far we’ve only written the models. The next step is writing the views and serializers so the client can access and manipulate the data in the database.
 
-![]()(./images/django-rest-process.png)
+![](./images/django-rest-process.png)
 
 
 


### PR DESCRIPTION
Looks like there was an extRA `()` in the image link in the Django View/Serializers interlude. Removing it to make the image appear in the readme again